### PR TITLE
fixing mvn clean install hanging

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <version>0.6.2</version>
   
   <properties>
-		<restlet-version>[2.3.12,)</restlet-version>
+		<restlet-version>2.4.1</restlet-version>
 	</properties>
 
 	<dependencies>


### PR DESCRIPTION
When trying to download this dependency, mvn hangs for a long time on some transitive dependency, with non existing repository